### PR TITLE
[STEP09] 동시성 문제 분석 및 적합한 DB Lock 기반 동시성 제어 로직 구현 및 검증

### DIFF
--- a/src/main/java/kr/hhplus/be/server/domain/coupon/CouponService.java
+++ b/src/main/java/kr/hhplus/be/server/domain/coupon/CouponService.java
@@ -10,19 +10,17 @@ public class CouponService {
 
     private final CouponRepository couponRepository;
 
+    @Transactional
     public Coupon issue(Long couponId) {
 
         Coupon coupon = couponRepository.findById(couponId);
 
-        /*
-         * TODO: 동시성 제어
-         * */
         Coupon issueCoupon = coupon.issue();
 
-        return save(issueCoupon);
+        return couponRepository.save(issueCoupon);
     }
 
-    @Transactional(readOnly = true)
+    @Transactional
     public Coupon findById(Long couponId) {
         return couponRepository.findById(couponId);
     }

--- a/src/main/java/kr/hhplus/be/server/domain/point/PointRepository.java
+++ b/src/main/java/kr/hhplus/be/server/domain/point/PointRepository.java
@@ -4,5 +4,5 @@ package kr.hhplus.be.server.domain.point;
 public interface PointRepository {
 
     Point findByUserId(Long userId);
-    void save(Point point);
+    Point save(Point point);
 }

--- a/src/main/java/kr/hhplus/be/server/domain/point/PointService.java
+++ b/src/main/java/kr/hhplus/be/server/domain/point/PointService.java
@@ -21,9 +21,7 @@ public class PointService {
 
         Point updateUserPoint = point.charge(amount);
 
-        pointRepository.save(updateUserPoint);
-
-        return updateUserPoint;
+        return pointRepository.save(updateUserPoint);
     }
 
     @Transactional
@@ -33,9 +31,7 @@ public class PointService {
 
         Point updateUserPoint = point.use(amount);
 
-        pointRepository.save(updateUserPoint);
-
-        return updateUserPoint;
+        return pointRepository.save(updateUserPoint);
     }
 
     @Transactional

--- a/src/main/java/kr/hhplus/be/server/domain/point/PointService.java
+++ b/src/main/java/kr/hhplus/be/server/domain/point/PointService.java
@@ -1,6 +1,7 @@
 package kr.hhplus.be.server.domain.point;
 
 
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -13,6 +14,7 @@ public class PointService {
 
     private final PointRepository pointRepository;
 
+    @Transactional
     public Point charge(Long userId, Long amount) {
 
         Point point = pointRepository.findByUserId(userId);
@@ -24,6 +26,7 @@ public class PointService {
         return updateUserPoint;
     }
 
+    @Transactional
     public Point use(Long userId, Long amount) {
 
         Point point = pointRepository.findByUserId(userId);
@@ -35,7 +38,12 @@ public class PointService {
         return updateUserPoint;
     }
 
-    public Point getUserPoint(Long userId) {
+    @Transactional
+    public Point findByUserId(Long userId) {
         return pointRepository.findByUserId(userId);
+    }
+
+    public Point save(Point point) {
+        return pointRepository.save(point);
     }
 }

--- a/src/main/java/kr/hhplus/be/server/domain/stock/StockService.java
+++ b/src/main/java/kr/hhplus/be/server/domain/stock/StockService.java
@@ -14,7 +14,7 @@ public class StockService {
 
     private final StockRepository stockRepository;
 
-    @Transactional(readOnly = true)
+    @Transactional
     public Stock findByProductId(Long productId) {
         return stockRepository.findByProductId(productId);
     }
@@ -24,6 +24,7 @@ public class StockService {
         stock.validateStockEnough(requestedQuantity);
     }
 
+    @Transactional
     public void deduct(Long productId, Long requestedQuantity) {
         Stock stock = stockRepository.findByProductId(productId);
         Stock deducted = stock.deduct(requestedQuantity);

--- a/src/main/java/kr/hhplus/be/server/infra/coupon/CouponRepositoryImpl.java
+++ b/src/main/java/kr/hhplus/be/server/infra/coupon/CouponRepositoryImpl.java
@@ -16,7 +16,7 @@ public class CouponRepositoryImpl implements CouponRepository {
 
     @Override
     public Coupon findById(Long couponId) {
-        return couponJpaRepository.findById(couponId)
+        return couponJpaRepository.findByCouponId(couponId)
                 .map(CouponEntity::toDomain)
                 .orElseThrow(() -> new IllegalArgumentException("쿠폰이 없습니다."));
     }

--- a/src/main/java/kr/hhplus/be/server/infra/coupon/jpa/CouponJpaRepository.java
+++ b/src/main/java/kr/hhplus/be/server/infra/coupon/jpa/CouponJpaRepository.java
@@ -1,9 +1,14 @@
 package kr.hhplus.be.server.infra.coupon.jpa;
 
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
 public interface CouponJpaRepository extends JpaRepository<CouponEntity, Long> {
-    Optional<CouponEntity> findById(Long couponId);
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select c from CouponEntity c where c.couponId = :couponId")
+    Optional<CouponEntity> findByCouponId(Long couponId);
 }

--- a/src/main/java/kr/hhplus/be/server/infra/point/PointRepositoryImpl.java
+++ b/src/main/java/kr/hhplus/be/server/infra/point/PointRepositoryImpl.java
@@ -23,8 +23,11 @@ public class PointRepositoryImpl implements PointRepository {
     }
 
     @Override
-    public void save(Point point){
-        PointEntity entity = PointEntity.toEntity(point);
-        pointJpaRepository.save(entity);
+    public Point save(Point point){
+        return PointEntity.toDomain(
+                pointJpaRepository.save(
+                        PointEntity.toEntity(point)
+                )
+        );
     }
 }

--- a/src/main/java/kr/hhplus/be/server/infra/point/jpa/PointJpaRepository.java
+++ b/src/main/java/kr/hhplus/be/server/infra/point/jpa/PointJpaRepository.java
@@ -1,10 +1,15 @@
 package kr.hhplus.be.server.infra.point.jpa;
 
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
 
 public interface PointJpaRepository extends JpaRepository<PointEntity, Long> {
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select p from PointEntity p where p.userId = :userId")
     Optional<PointEntity> findByUserId(Long userId);
 }

--- a/src/main/java/kr/hhplus/be/server/infra/stock/jpa/StockJpaRepository.java
+++ b/src/main/java/kr/hhplus/be/server/infra/stock/jpa/StockJpaRepository.java
@@ -1,8 +1,12 @@
 package kr.hhplus.be.server.infra.stock.jpa;
 
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
 public interface StockJpaRepository extends JpaRepository<StockEntity, Long> {
-
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select c from StockEntity c where c.productId = :productId")
     StockEntity findByProductId(Long productId);
 }

--- a/src/test/java/kr/hhplus/be/server/domain/point/PointConcurrencyTest.java
+++ b/src/test/java/kr/hhplus/be/server/domain/point/PointConcurrencyTest.java
@@ -1,0 +1,66 @@
+package kr.hhplus.be.server.domain.point;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDateTime;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+public class PointConcurrencyTest {
+
+    @Autowired
+    private PointService pointService;
+
+    @Autowired
+    private PointRepository pointRepository;
+
+    @Test
+    @DisplayName("포인트 충전과 사용이 동시에 요청시 순차적으로 성공해야 한다.")
+    void deductStockConcurrencyFailTest() throws InterruptedException {
+
+        Point point = Point.builder()
+                .pointId(null)
+                .userId(1L)
+                .point(100L)
+                .updatedAt(LocalDateTime.now())
+                .build();
+        Point savedPoint = pointService.save(point);
+
+        int threadCount = 1;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount*2);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(() -> {
+                try {
+                    pointService.charge(1L, 5L);
+                } finally {
+                    latch.countDown();
+                }
+            });
+
+            executor.submit(() -> {
+                try {
+                    pointService.use(1L, 1L);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        Point result = pointService.findByUserId(1L);
+
+        // 100 + (5) = 105
+        // 105 - (1) = 104
+        assertThat(result.point()).isEqualTo(104);
+    }
+}

--- a/src/test/java/kr/hhplus/be/server/domain/point/PointConcurrencyTest.java
+++ b/src/test/java/kr/hhplus/be/server/domain/point/PointConcurrencyTest.java
@@ -13,6 +13,7 @@ import java.util.concurrent.Executors;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
+@DisplayName("포인트 동시성 테스트")
 public class PointConcurrencyTest {
 
     @Autowired

--- a/src/test/java/kr/hhplus/be/server/domain/point/PointServiceIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/server/domain/point/PointServiceIntegrationTest.java
@@ -4,6 +4,7 @@ import kr.hhplus.be.server.domain.user.User;
 import kr.hhplus.be.server.infra.point.PointRepositoryImpl;
 import kr.hhplus.be.server.infra.point.jpa.PointEntity;
 import kr.hhplus.be.server.infra.point.jpa.PointJpaRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,6 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @Transactional
+@DisplayName("포인트 서비스 통합 테스트")
 public class PointServiceIntegrationTest {
 
     @Autowired
@@ -25,12 +27,19 @@ public class PointServiceIntegrationTest {
     @Autowired
     private PointRepository pointRepository;
 
+    @Autowired
+    private PointJpaRepository pointJpaRepository;
+
+    @BeforeEach
+    void setup() {
+        pointJpaRepository.deleteAll();
+    }
+
 
     @Test
     @DisplayName("포인트_충전_후_잔액_확인")
     void chargePointSuccess() {
         // given
-//        Long pointId = 1L;
         Long userId = 1L;
         Long amount = 500L;
         Point point = Point.builder()
@@ -42,10 +51,9 @@ public class PointServiceIntegrationTest {
         pointRepository.save(point);
 
         // when
-        pointService.charge(userId, amount);
+        Point savedPoint = pointService.charge(userId, amount);
 
         // then
-        Point result = pointRepository.findByUserId(userId);
-        assertThat(result.point()).isEqualTo(500L);
+        assertThat(savedPoint.point()).isEqualTo(500L);
     }
 }

--- a/src/test/java/kr/hhplus/be/server/domain/point/PointServiceTest.java
+++ b/src/test/java/kr/hhplus/be/server/domain/point/PointServiceTest.java
@@ -93,7 +93,7 @@ class PointServiceTest {
         given(pointRepository.findByUserId(userId)).willReturn(point);
 
         // when
-        Point userPoint = pointService.getUserPoint(userId);
+        Point userPoint = pointService.findByUserId(userId);
 
         //then
         assertThat(userPoint).isNotNull();

--- a/src/test/java/kr/hhplus/be/server/domain/point/PointServiceTest.java
+++ b/src/test/java/kr/hhplus/be/server/domain/point/PointServiceTest.java
@@ -39,6 +39,8 @@ class PointServiceTest {
                 .build();
 
         given(pointRepository.findByUserId(userId)).willReturn(point);
+        given(pointRepository.save(any(Point.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
 
         // when
         Point updatePoint = pointService.charge(userId, amount);
@@ -65,6 +67,8 @@ class PointServiceTest {
                 .build();
 
         given(pointRepository.findByUserId(userId)).willReturn(point);
+        given(pointRepository.save(any(Point.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
 
         // when
         Point updatePoint = pointService.use(userId, amount);

--- a/src/test/java/kr/hhplus/be/server/domain/stock/StockConcurrencyTest.java
+++ b/src/test/java/kr/hhplus/be/server/domain/stock/StockConcurrencyTest.java
@@ -1,0 +1,57 @@
+package kr.hhplus.be.server.domain.stock;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDateTime;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+public class StockConcurrencyTest {
+
+    @Autowired
+    private StockService stockService;
+
+    @Autowired
+    private StockRepository stockRepository;
+
+    @Test
+    @DisplayName("재고 차감을 요청시 모든 요청에 대한 재고 차감이 이루어져야 한다.")
+    void deductStockConcurrencyFailTest() throws InterruptedException {
+        int threadCount = 100;
+
+        Stock stock = Stock.builder()
+                .stockId(null)
+                .productId(1L)
+                .quantity(threadCount)
+                .updatedAt(LocalDateTime.now())
+                .build();
+        Stock savedStock = stockService.save(stock);
+
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(() -> {
+                try {
+                    stockService.deduct(1L, 1L);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        Stock result = stockService.findByProductId(savedStock.productId());
+
+        // 100 - (100) = 0
+        assertThat(result.quantity()).isEqualTo(0);
+    }
+}

--- a/src/test/java/kr/hhplus/be/server/domain/stock/StockServiceIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/server/domain/stock/StockServiceIntegrationTest.java
@@ -1,5 +1,7 @@
 package kr.hhplus.be.server.domain.stock;
 
+import kr.hhplus.be.server.infra.stock.jpa.StockJpaRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,6 +22,14 @@ public class StockServiceIntegrationTest {
 
     @Autowired
     private StockRepository stockRepository;
+
+    @Autowired
+    private StockJpaRepository stockJpaRepository;
+
+    @BeforeEach
+    void setup() {
+        stockJpaRepository.deleteAll();
+    }
 
     @Test
     @DisplayName("재고_조회")


### PR DESCRIPTION
<!--
  제목은 [(과제 STEP)] (작업한 내용) 로 작성해 주세요
  예시: [STEP-5] 이커머스 시스템 설계 
-->
## 참고 자료
- #17 
<!--
  (Optional: 참고 자료가 없는 작업 - 단순 버그 픽스 등 의 경우엔 해당 란을 제거해주세요 !)
  작업에 대한 참고자료(PR, 피그마, 슬랙 등)가 있는 경우 링크를 참고 자료에 같이 추가해주세요.
  히스토리나 정책, 특정 기술 등에 대한 이해가 필요한 작업일 때 참고자료가 있다면 리뷰어에게 큰 도움이 됩니다!
-->

## PR 설명
<!-- 해당 PR이 왜 발생했고, 어떤부분에 대한 작업인지 작성해주세요. -->
- 동시성 제어 구현
  - 포인트 충전/사용 동시성 제어 비관적 락 적용: 166ea1bbb5a6bd6487629c9d11b2a174a58c03f1
  - 쿠폰 발급 동시성 제어 비관적 락 적용: 5b8d77363df6c3cd5f190621517d3bffa26c135d
  - 재고 차감 동시성 제어 비관적 락 적용: 83aa23293315ed5e081dfb01c3458f2fe4a79139
- 동시성 문제 분석 보고서
  - [바로가기](https://deciduous-clarinet-874.notion.site/1df804fe9c6680bb8a65d9576ff0e52e?pvs=4)

## 리뷰 포인트
<!-- 
    리뷰어가 함께 고민해주었으면 하는 내용을 간략하게 기재해주세요.
    커밋 링크가 포함되면, 더욱이 효과적일 거예요! 
-->
- 포인트 충전/사용 요청시 동시성 이슈에 대해서 JPA의 `@Version`을  이용한 낙관적 락을 시도해 보았습니다. 그런데 `@Version`은 JPA엔티티가 영속성 컨텍스트에 의해 관리될때만 작동하기 때문에 원래 의도 실현이 불가능했습니다.
현재 구조상 도메인과 엔티티의 레이어를 분리되어있고 도메인 객체를 별도로 사용하여 저장시 toEntity()를 사용해 새 객체를 생성하다보니 `@Version`을 사용할 수 없었습니다.(더티체킹 불가)
그래서 결국 비관적 락을 적용하여서 동시성 이슈를 해결하였는데 적절하였는지 검토 부탁드립니다.

## KPT 회고
**Keep**
- 끊임 없는 리팩토링을 하였습니다.

**Problem**
- 끊임 없는 리팩토링이 문제였습니다.. 중요한건 적당한 범위의 과제가 가능한 수준으로의 리팩토링이 중요한것 같습니다.

**Try**
- 심화과제 부족한 부분도 채워보려 합니다.
